### PR TITLE
remove outdated error messages

### DIFF
--- a/NisApi.src.html
+++ b/NisApi.src.html
@@ -6928,9 +6928,6 @@
         <dt>FAILURE_SIGNATURE_NOT_VERIFIABLE</dt>
         <dd>The signature of the entity failed upon verification.</dd>
 
-        <dt>FAILURE_TIMESTAMP_TOO_FAR_IN_PAST</dt>
-        <dd>The timestamp of the entity lies to far in the past.</dd>
-
         <dt>FAILURE_TIMESTAMP_TOO_FAR_IN_FUTURE</dt>
         <dd>The timestamp of the entity lies too far in the future.</dd>
 


### PR DESCRIPTION
Was not able to replicate: "FAILURE_TIMESTAMP_TOO_FAR_IN_PAST". There might be more error messages that are not in production.